### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 matrix:
    fast_finish: true
 
@@ -13,13 +15,10 @@ cache:
     - $HOME/.composer/cache
     - vendor
 
-before_install:
-  - sudo apt-get update -qq
 install:
   - phpenv config-rm xdebug.ini || echo "xdebug is not installed"
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - travis_retry composer self-update && composer --version
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - travis_retry composer install --prefer-dist --no-interaction
 
-script: phpunit -vvv
+script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,12 @@
     } ,
     "autoload":    {
         "psr-4": {
-            "insolita\\cqueue\\tests\\": "tests/" ,
             "insolita\\cqueue\\":        "src/"
+        }
+    },
+    "autoload-dev":    {
+        "psr-4": {
+            "insolita\\cqueue\\tests\\": "tests/"
         }
     }
 }

--- a/tests/Functional/FunctionalPredisTest.php
+++ b/tests/Functional/FunctionalPredisTest.php
@@ -20,7 +20,7 @@ class FunctionalPredisTest extends TestCase
      */
     private $queue;
     
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $predis = new Client([

--- a/tests/Functional/FunctionalRedisTest.php
+++ b/tests/Functional/FunctionalRedisTest.php
@@ -20,7 +20,7 @@ class FunctionalRedisTest extends TestCase
      */
     private $queue;
     
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $redis = new Redis();

--- a/tests/Functional/StorageSameTest.php
+++ b/tests/Functional/StorageSameTest.php
@@ -24,7 +24,7 @@ class StorageSameTest extends TestCase
      */
     private $phpRedisStorage;
     
-    public function setUp()
+    protected function setUp()
     {
         $predis = new Client([
             'host' => '127.0.0.1',

--- a/tests/Unit/CircularQueueTest.php
+++ b/tests/Unit/CircularQueueTest.php
@@ -26,7 +26,7 @@ class CircularQueueTest extends TestCase
      **/
     private $queue;
     
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->redis = Mockery::mock(PhpRedisStorage::class);

--- a/tests/Unit/SerializableConverterTest.php
+++ b/tests/Unit/SerializableConverterTest.php
@@ -27,7 +27,7 @@ class SerializableConverterTest extends TestCase
      */
     private $redis;
     
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->redis = Mockery::mock(PhpRedisStorage::class);

--- a/tests/Unit/SimpleCircularQueueTest.php
+++ b/tests/Unit/SimpleCircularQueueTest.php
@@ -25,7 +25,7 @@ class SimpleCircularQueueTest extends TestCase
      */
     private $redis;
     
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->redis = Mockery::mock(PhpRedisStorage::class);

--- a/tests/Unit/StorageTest.php
+++ b/tests/Unit/StorageTest.php
@@ -15,28 +15,28 @@ use Redis;
 class StorageTest extends TestCase
 {
     use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-    
+
     /**
      * @var \Redis|\Mockery\MockInterface $phpRedis
      */
     private $phpRedis;
-    
+
     /**
      * @var Client|\Mockery\MockInterface $predis
      */
     private $predis;
-    
+
     /**
      * @var PhpRedisStorage
      */
     private $phpRedisStorage;
-    
+
     /**
      * @var PredisStorage
      */
     private $predisStorage;
-    
-    public function setUp()
+
+    protected function setUp()
     {
         parent::setUp();
         $this->phpRedis = Mockery::mock(Redis::class);
@@ -44,7 +44,7 @@ class StorageTest extends TestCase
         $this->predisStorage = new PredisStorage($this->predis);
         $this->phpRedisStorage = new PhpRedisStorage($this->phpRedis);
     }
-    
+
     public function testDelete()
     {
         $this->predis->shouldReceive('del')->withArgs([['key']]);
@@ -52,7 +52,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('del')->withArgs(['key']);
         $this->phpRedisStorage->delete('key');
     }
-    
+
     public function testListCount()
     {
         $this->predis->shouldReceive('llen')->withArgs(['key']);
@@ -60,7 +60,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('lLen')->withArgs(['key']);
         $this->phpRedisStorage->listCount('key');
     }
-    
+
     public function testListItems()
     {
         $this->predis->shouldReceive('lrange')->withArgs(['key', 0, -1])->andReturn([]);
@@ -68,7 +68,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('lrange')->withArgs(['key', 0, -1])->andReturn([]);
         $this->phpRedisStorage->listItems('key');
     }
-    
+
     public function testListPop()
     {
         $this->predis->shouldReceive('rpop')->withArgs(['key']);
@@ -76,7 +76,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('rPop')->withArgs(['key']);
         $this->phpRedisStorage->listPop('key');
     }
-    
+
     public function testListPush()
     {
         $this->predis->shouldReceive('lpush')->withArgs(['key', ['foo', 'bar']]);
@@ -85,7 +85,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('lPush')->withArgs(['key', 'bar']);
         $this->phpRedisStorage->listPush('key', ['foo', 'bar']);
     }
-    
+
     public function testZSetCount()
     {
         $this->predis->shouldReceive('zcard')->withArgs(['key']);
@@ -93,7 +93,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('zCard')->withArgs(['key']);
         $this->phpRedisStorage->zSetCount('key');
     }
-    
+
     public function testZSetItems()
     {
         $this->predis->shouldReceive('zrange')->withArgs(['key', 0, -1])->andReturn([]);
@@ -101,7 +101,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('zRange')->withArgs(['key', 0, -1])->andReturn([]);
         $this->phpRedisStorage->zSetItems('key');
     }
-    
+
     public function testZSetExpiredItems()
     {
         $time = time();
@@ -110,7 +110,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('zRevRangeByScore')->withArgs(['key', $time, '-inf'])->andReturn([]);
         $this->phpRedisStorage->zSetExpiredItems('key', $time);
     }
-    
+
     public function testZSetPush()
     {
         $this->predis->shouldReceive('zadd')->withArgs(['key', ['foo' => 100]]);
@@ -118,7 +118,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('zAdd')->withArgs(['key', 100, 'foo']);
         $this->phpRedisStorage->zSetPush('key', 100, 'foo');
     }
-    
+
     public function testZSetRem()
     {
         $this->predis->shouldReceive('zrem')->withArgs(['key', 'foo']);
@@ -126,7 +126,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('zRem')->withArgs(['key', 'foo']);
         $this->phpRedisStorage->zSetRem('key', 'foo');
     }
-    
+
     public function testZSetExists()
     {
         $this->predis->shouldReceive('zScore')->withArgs(['key', 'foo'])->andReturn(1);
@@ -154,7 +154,7 @@ class StorageTest extends TestCase
         $result = $this->phpRedisStorage->zSetExists('key', 'baz');
         expect($result)->false();
     }
-    
+
     public function testMoveFromZSetToListExisted()
     {
         $this->predis->shouldReceive('zrem')->withArgs(['zkey', 'foo'])->andReturn(1);
@@ -164,7 +164,7 @@ class StorageTest extends TestCase
         $this->phpRedis->shouldReceive('lPush')->withArgs(['key', 'foo']);
         $this->phpRedisStorage->moveFromZSetToList('key', 'zkey', 'foo');
     }
-    
+
     public function testMoveFromZSetToListAbsent()
     {
         $this->predis->shouldReceive('zrem')->withArgs(['zkey', 'foo'])->andReturn(0);


### PR DESCRIPTION
# Changed log
- According to [PHPUnit fixtures](https://phpunit.de/manual/6.5/en/fixtures.html), the `setUp` method should be `protected`, not `public`.
- Remove unused command during Travis CI build work.
- Remove unused white spaces.